### PR TITLE
APICM-1840: Upgrade samples to use Vonage client-sdk-video 2.32.1

### DIFF
--- a/JetpackCompose/BasicVideoChat/gradle/libs.versions.toml
+++ b/JetpackCompose/BasicVideoChat/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ activityCompose = "1.8.0"
 composeBom = "2024.09.00"
 foundation = "1.9.4"
 foundationLayout = "1.9.4"
-vonage-video = "2.31.0"
+vonage-video = "2.32.1"
 runtime = "1.10.0"
 
 [libraries]

--- a/XML/Advanced-Audio-Driver/app/build.gradle
+++ b/XML/Advanced-Audio-Driver/app/build.gradle
@@ -38,7 +38,7 @@ android {
 
 dependencies {
     // Dependency versions are defined in the ../../commons.gradle file
-    implementation "com.opentok.android:opentok-android-sdk:${extOpentokSdkVersion}"
+    implementation "com.vonage:client-sdk-video:${extVonageSdkVersion}"
     implementation "androidx.appcompat:appcompat:${extAppCompatVersion}"
     implementation "pub.devrel:easypermissions:${extEasyPermissionsVersion}"
 }

--- a/XML/Archiving/app/build.gradle
+++ b/XML/Archiving/app/build.gradle
@@ -38,7 +38,7 @@ android {
 
 dependencies {
     // Dependency versions are defined in the ../../commons.gradle file
-    implementation "com.opentok.android:opentok-android-sdk:${extOpentokSdkVersion}"
+    implementation "com.vonage:client-sdk-video:${extVonageSdkVersion}"
     implementation "pub.devrel:easypermissions:${extEasyPermissionsVersion}"
     implementation "androidx.appcompat:appcompat:${extAppCompatVersion}"
     implementation "androidx.constraintlayout:constraintlayout:${extConstraintLyoutVersion}"

--- a/XML/Basic-Audio-Driver/app/build.gradle
+++ b/XML/Basic-Audio-Driver/app/build.gradle
@@ -38,7 +38,7 @@ android {
 
 dependencies {
     // Dependency versions are defined in the ../../commons.gradle file
-    implementation "com.opentok.android:opentok-android-sdk:${extOpentokSdkVersion}"
+    implementation "com.vonage:client-sdk-video:${extVonageSdkVersion}"
     implementation "androidx.appcompat:appcompat:${extAppCompatVersion}"
     implementation "pub.devrel:easypermissions:${extEasyPermissionsVersion}"
 }

--- a/XML/Basic-Video-Chat-ConnectionService/app/build.gradle
+++ b/XML/Basic-Video-Chat-ConnectionService/app/build.gradle
@@ -41,10 +41,10 @@ android {
     }
 }
 
-def extOpentokSdkVersion = ext.extOpentokSdkVersion
+def extVonageSdkVersion = ext.extVonageSdkVersion
 
 dependencies {
-    implementation "com.opentok.android:opentok-android-sdk:${extOpentokSdkVersion}"
+    implementation "com.vonage:client-sdk-video:${extVonageSdkVersion}"
 
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)

--- a/XML/Basic-Video-Chat-With-ForegroundServices/app/build.gradle
+++ b/XML/Basic-Video-Chat-With-ForegroundServices/app/build.gradle
@@ -38,7 +38,7 @@ android {
 
 dependencies {
     // Dependency versions are defined in the ../../commons.gradle file
-    implementation "com.opentok.android:opentok-android-sdk:${extOpentokSdkVersion}"
+    implementation "com.vonage:client-sdk-video:${extVonageSdkVersion}"
     implementation "androidx.core:core-ktx:1.15.0"
     implementation "androidx.appcompat:appcompat:${extAppCompatVersion}"
     implementation "pub.devrel:easypermissions:${extEasyPermissionsVersion}"

--- a/XML/Basic-Video-Chat/app/build.gradle
+++ b/XML/Basic-Video-Chat/app/build.gradle
@@ -38,7 +38,7 @@ android {
 
 dependencies {
     // Dependency versions are defined in the ../../commons.gradle file
-    implementation "com.opentok.android:opentok-android-sdk:${extOpentokSdkVersion}"
+    implementation "com.vonage:client-sdk-video:${extVonageSdkVersion}"
     implementation "androidx.appcompat:appcompat:${extAppCompatVersion}"
     implementation "pub.devrel:easypermissions:${extEasyPermissionsVersion}"
     implementation "androidx.constraintlayout:constraintlayout:${extConstraintLyoutVersion}"

--- a/XML/Camera-Controls/app/build.gradle
+++ b/XML/Camera-Controls/app/build.gradle
@@ -38,8 +38,8 @@ android {
 
 dependencies {
     // Dependency versions are defined in the ../../commons.gradle file
-    implementation "com.vonage:client-sdk-video:${extOpentokSdkVersion}"
-    implementation "com.vonage:client-sdk-video-transformers:${extOpentokSdkVersion}"
+    implementation "com.vonage:client-sdk-video:${extVonageSdkVersion}"
+    implementation "com.vonage:client-sdk-video-transformers:${extVonageSdkVersion}"
     implementation "androidx.appcompat:appcompat:${extAppCompatVersion}"
     implementation "pub.devrel:easypermissions:${extEasyPermissionsVersion}"
     implementation "androidx.constraintlayout:constraintlayout:${extConstraintLyoutVersion}"

--- a/XML/E2EE-Video-Chat/app/build.gradle
+++ b/XML/E2EE-Video-Chat/app/build.gradle
@@ -38,7 +38,7 @@ android {
 
 dependencies {
     // Dependency versions are defined in the ../../commons.gradle file
-    implementation "com.opentok.android:opentok-android-sdk:2.27.0"
+    implementation "com.vonage:client-sdk-video:${extVonageSdkVersion}"
     implementation "androidx.appcompat:appcompat:${extAppCompatVersion}"
     implementation "pub.devrel:easypermissions:${extEasyPermissionsVersion}"
     implementation "androidx.constraintlayout:constraintlayout:${extConstraintLyoutVersion}"

--- a/XML/Live-Photo-Capture/app/build.gradle
+++ b/XML/Live-Photo-Capture/app/build.gradle
@@ -38,7 +38,7 @@ android {
 
 dependencies {
     // Dependency versions are defined in the ../../commons.gradle file
-    implementation "com.opentok.android:opentok-android-sdk:${extOpentokSdkVersion}"
+    implementation "com.vonage:client-sdk-video:${extVonageSdkVersion}"
     implementation "androidx.appcompat:appcompat:${extAppCompatVersion}"
     implementation "pub.devrel:easypermissions:${extEasyPermissionsVersion}"
 }

--- a/XML/Media-Transformers/app/build.gradle
+++ b/XML/Media-Transformers/app/build.gradle
@@ -38,8 +38,8 @@ android {
 
 dependencies {
     // Dependency versions are defined in the ../../commons.gradle file
-    implementation "com.vonage:client-sdk-video:${extOpentokSdkVersion}"
-    implementation "com.vonage:client-sdk-video-transformers:${extOpentokSdkVersion}"
+    implementation "com.vonage:client-sdk-video:${extVonageSdkVersion}"
+    implementation "com.vonage:client-sdk-video-transformers:${extVonageSdkVersion}"
     implementation "androidx.appcompat:appcompat:${extAppCompatVersion}"
     implementation "pub.devrel:easypermissions:${extEasyPermissionsVersion}"
     implementation "androidx.constraintlayout:constraintlayout:${extConstraintLyoutVersion}"

--- a/XML/Multiparty-Constraint-Layout/app/build.gradle
+++ b/XML/Multiparty-Constraint-Layout/app/build.gradle
@@ -39,7 +39,7 @@ android {
 
 dependencies {
     // Dependency versions are defined in the ../../commons.gradle file
-    implementation "com.opentok.android:opentok-android-sdk:${extOpentokSdkVersion}"
+    implementation "com.vonage:client-sdk-video:${extVonageSdkVersion}"
     implementation "androidx.appcompat:appcompat:${extAppCompatVersion}"
     implementation "pub.devrel:easypermissions:${extEasyPermissionsVersion}"
     implementation "androidx.constraintlayout:constraintlayout:${extConstraintLyoutVersion}"

--- a/XML/Phone-Call-Detection/app/build.gradle
+++ b/XML/Phone-Call-Detection/app/build.gradle
@@ -38,7 +38,7 @@ android {
 
 dependencies {
     // Dependency versions are defined in the ../../commons.gradle file
-    implementation "com.vonage:client-sdk-video:${extOpentokSdkVersion}"
+    implementation "com.vonage:client-sdk-video:${extVonageSdkVersion}"
     implementation "androidx.appcompat:appcompat:${extAppCompatVersion}"
     implementation "pub.devrel:easypermissions:${extEasyPermissionsVersion}"
     implementation "androidx.constraintlayout:constraintlayout:${extConstraintLyoutVersion}"

--- a/XML/Webview-Screen-Sharing/app/build.gradle
+++ b/XML/Webview-Screen-Sharing/app/build.gradle
@@ -38,7 +38,7 @@ android {
 
 dependencies {
     // Dependency versions are defined in the ../../commons.gradle file
-    implementation "com.opentok.android:opentok-android-sdk:${extOpentokSdkVersion}"
+    implementation "com.vonage:client-sdk-video:${extVonageSdkVersion}"
     implementation "androidx.appcompat:appcompat:${extAppCompatVersion}"
     implementation "pub.devrel:easypermissions:${extEasyPermissionsVersion}"
     implementation "androidx.constraintlayout:constraintlayout:${extConstraintLyoutVersion}"

--- a/XML/commons.gradle
+++ b/XML/commons.gradle
@@ -12,7 +12,7 @@ ext {
     extVersionCode=1
     extVersionName="1.0"
     extMinifyEnabled=false
-    extOpentokSdkVersion="2.31.1"
+    extVonageSdkVersion="2.32.1"
     extAppCompatVersion="1.4.1"
     extEasyPermissionsVersion="3.0.0"
     extConstraintLyoutVersion="2.0.4"


### PR DESCRIPTION
* Change the name of the `extOpentokSdkVersion` variable in `common.gradle` to `extVonageSdkVersion`.
* Upgrade the SDK version to 2.32.1
* Change the Opentok SDK in gradle files for the Vonage one.
* For Jetpack Compose Basic Video Chat sample, the Vonage SDK has been upgraded to 2.32.1 in `libs.versions.toml`