### PR TITLE
APICM-7456: Upgrade Video Android SDK to v2.34.0

### DIFF
--- a/JetpackCompose/Basic-Video-Renderer/app/build.gradle.kts
+++ b/JetpackCompose/Basic-Video-Renderer/app/build.gradle.kts
@@ -58,5 +58,5 @@ dependencies {
     androidTestImplementation(libs.androidx.compose.ui.test.junit4)
     debugImplementation(libs.androidx.compose.ui.tooling)
     debugImplementation(libs.androidx.compose.ui.test.manifest)
-    implementation("com.vonage:client-sdk-video:2.31.0")
+    implementation(libs.vonage.video)
 }

--- a/JetpackCompose/Basic-Video-Renderer/gradle/libs.versions.toml
+++ b/JetpackCompose/Basic-Video-Renderer/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ activityCompose = "1.8.0"
 composeBom = "2024.09.00"
 foundation = "1.9.4"
 foundationLayout = "1.9.4"
+vonage-video = "2.34.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -28,6 +29,7 @@ androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-te
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-compose-foundation = { group = "androidx.compose.foundation", name = "foundation", version.ref = "foundation" }
 androidx-compose-foundation-layout = { group = "androidx.compose.foundation", name = "foundation-layout", version.ref = "foundationLayout" }
+vonage-video = { group = "com.vonage", name = "client-sdk-video", version.ref = "vonage-video" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/JetpackCompose/BasicVideoCapturer/app/build.gradle.kts
+++ b/JetpackCompose/BasicVideoCapturer/app/build.gradle.kts
@@ -58,5 +58,5 @@ dependencies {
     androidTestImplementation(libs.androidx.compose.ui.test.junit4)
     debugImplementation(libs.androidx.compose.ui.tooling)
     debugImplementation(libs.androidx.compose.ui.test.manifest)
-    implementation("com.vonage:client-sdk-video:2.31.0")
+    implementation(libs.vonage.video)
 }

--- a/JetpackCompose/BasicVideoCapturer/gradle/libs.versions.toml
+++ b/JetpackCompose/BasicVideoCapturer/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ activityCompose = "1.8.0"
 composeBom = "2024.09.00"
 foundation = "1.9.4"
 foundationLayout = "1.9.4"
+vonage-video = "2.34.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -28,6 +29,7 @@ androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-te
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-compose-foundation = { group = "androidx.compose.foundation", name = "foundation", version.ref = "foundation" }
 androidx-compose-foundation-layout = { group = "androidx.compose.foundation", name = "foundation-layout", version.ref = "foundationLayout" }
+vonage-video = { group = "com.vonage", name = "client-sdk-video", version.ref = "vonage-video" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/JetpackCompose/BasicVideoChat/gradle/libs.versions.toml
+++ b/JetpackCompose/BasicVideoChat/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ activityCompose = "1.8.0"
 composeBom = "2024.09.00"
 foundation = "1.9.4"
 foundationLayout = "1.9.4"
-vonage-video = "2.32.1"
+vonage-video = "2.34.0"
 runtime = "1.10.0"
 
 [libraries]

--- a/JetpackCompose/CustomAudioDriver/gradle/libs.versions.toml
+++ b/JetpackCompose/CustomAudioDriver/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ activityCompose = "1.8.0"
 composeBom = "2024.09.00"
 foundation = "1.9.4"
 foundationLayout = "1.9.4"
-vonage-video = "2.31.0"
+vonage-video = "2.34.0"
 runtime = "1.10.0"
 
 [libraries]

--- a/JetpackCompose/ScreenSharing/app/build.gradle.kts
+++ b/JetpackCompose/ScreenSharing/app/build.gradle.kts
@@ -58,5 +58,5 @@ dependencies {
     androidTestImplementation(libs.androidx.compose.ui.test.junit4)
     debugImplementation(libs.androidx.compose.ui.tooling)
     debugImplementation(libs.androidx.compose.ui.test.manifest)
-    implementation("com.vonage:client-sdk-video:2.31.0")
+    implementation(libs.vonage.video)
 }

--- a/JetpackCompose/ScreenSharing/gradle/libs.versions.toml
+++ b/JetpackCompose/ScreenSharing/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ activityCompose = "1.8.0"
 composeBom = "2024.09.00"
 foundation = "1.9.4"
 foundationLayout = "1.9.4"
+vonage-video = "2.34.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -28,6 +29,7 @@ androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-te
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-compose-foundation = { group = "androidx.compose.foundation", name = "foundation", version.ref = "foundation" }
 androidx-compose-foundation-layout = { group = "androidx.compose.foundation", name = "foundation-layout", version.ref = "foundationLayout" }
+vonage-video = { group = "com.vonage", name = "client-sdk-video", version.ref = "vonage-video" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/XML/commons.gradle
+++ b/XML/commons.gradle
@@ -12,7 +12,7 @@ ext {
     extVersionCode=1
     extVersionName="1.0"
     extMinifyEnabled=false
-    extVonageSdkVersion="2.33.0"
+    extVonageSdkVersion="2.34.0"
     extAppCompatVersion="1.4.1"
     extEasyPermissionsVersion="3.0.0"
     extConstraintLyoutVersion="2.0.4"


### PR DESCRIPTION
Upgrade Android SDK version to 2.34.0

[Ticket](https://jira.vonage.com/browse/APICM-7456)